### PR TITLE
#terminate instance on user disconnection

### DIFF
--- a/Leonid/gateway.py
+++ b/Leonid/gateway.py
@@ -62,8 +62,18 @@ class GatewayApp:
             except Exception as e:
                 logging.error(f"Gateway: invalid request received: {request_content} - {e}")
                 return {"error": f"Invalid request"}
-            # TO DO
-            pass
+
+            # Getting user name and user token - the former is used to verify the current user is authorized
+            user_name, user_token = self.extract_user_data(user_data)
+            token_validation = self.user_token_validator(user_token)
+
+            if token_validation is False:
+                logging.warning(f"Gateway: authorization issue - user {user_name} tried to use"
+                                f" an invalid access token {user_token}")
+                return {"error": "Access denied"}
+
+            logging.info(f"Gateway: forwarding user disconnection notification - {user_name}")
+            return MiddleLayer.user_disconnection_internal_handling(user_name)
 
     def run(self, host='0.0.0.0', port=5001):
         self.app.run(host=host, port=port)

--- a/Leonid/gateway.py
+++ b/Leonid/gateway.py
@@ -10,20 +10,26 @@ except ModuleNotFoundError:
 
 logging.basicConfig(level=logging.INFO)
 
-# TO DO:
-#
-# 1. Add API method that will be used to stop and remove unused Chatbot instances - it will receive (disconnected)
-#    user name from ISeeCubes and pass it to the MidLayer, the former will stop the instance that is mapped to that name.
 
 class GatewayApp:
+
     def __init__(self):
         self.app = Flask(__name__)
 
         @self.app.route("/receive_prompt", methods=['POST'])
         def receive_user_prompt():
+            """
+            This method parses user name and token packed in a JWT, and providing those are valid
+            the user's name (extracted from JWT) and user's prompt are forwarded to Vicuna language model
+            (through MiddleLayer). Response provided by the model is returned (if there is no response - the relevant
+            error message or notification is returned).
+            # NOTE: At the moment user's token isn't validated, the auth. module will be added later.
+            :return: str
+            """
             request_content = request.get_json()
 
             try:
+                # Verifying user input
                 user_data = request_content['user_data']  # User name & token as JWT
                 user_prompt = request_content['user_prompt']
 
@@ -44,13 +50,20 @@ class GatewayApp:
                 return {"error": "Access denied"}
 
             logging.info(f"Gateway: Forwarding to the model {user_name} : {user_prompt}")
-            # return {"test": "ok"}
 
             # Forwarding user name and user prompt to the model
             return MiddleLayer.handle_user_prompt(user_name, user_prompt)
 
         @self.app.route("/user_disconnection", methods=['POST'])
         def handle_user_disconnection():
+            """
+            This method handles user disconnection notification.
+            When a user that has a conversation with the chat bot terminates connection
+            the chat bot should be notified via this API method. After user name and token are
+            validated user's name is passed to the MiddleLayer, and the bot instance that had a conversation
+            with that given user is stopped and removed.
+            :return: dict with result report
+            """
             request_content = request.get_json()
 
             try:
@@ -79,6 +92,15 @@ class GatewayApp:
         self.app.run(host=host, port=port)
 
     def extract_user_data(self, jwt_token):
+        """
+        Extracts user data from a JWT (JSON Web Token).
+
+        Parameters:
+           jwt_token (str): The JWT token to decode and extract user data from.
+        Returns:
+           tuple: A tuple containing user-related data extracted from the JWT.
+                  The tuple contains two elements: user name and user token.
+       """
 
         # Decode the JWT without verifying the signature
         decoded_payload = jwt.decode(jwt_token, algorithms=["HS256"], options={"verify_signature": False})

--- a/Leonid/midlayer.py
+++ b/Leonid/midlayer.py
@@ -58,7 +58,7 @@ class MiddleLayer:
 
     @classmethod
     def user_disconnection_internal_handling(cls, user_name):
-        # TO DO 
+        # TO DO
         pass
 
 

--- a/Leonid/midlayer.py
+++ b/Leonid/midlayer.py
@@ -7,6 +7,7 @@ except ModuleNotFoundError:
     from chatbot import ChatBot
 
 logging.basicConfig(level=logging.INFO)
+DEFAULT_ERROR_MESSAGE = "Sorry. I don't feel well. I don't think we can speak right now. Please call later."
 
 # TO DO:
 #
@@ -48,7 +49,13 @@ class MiddleLayer:
             logging.info(f"Middle Layer: initiating a new conversation for user {user_name}")
             new_conversation_partner = ChatBot()
             cls.users_conversations[user_name] = new_conversation_partner
-            return new_conversation_partner.send_prompt(user_prompt)
+
+            try:
+                return new_conversation_partner.send_prompt(user_prompt)
+
+            except OSError as e:
+                logging.critical(f"Middle Layer: Chat bot doesn't respond - {e}")
+                return DEFAULT_ERROR_MESSAGE
 
         else:
             # Forwarding user prompt to the related ChatBot instance
@@ -58,8 +65,17 @@ class MiddleLayer:
 
     @classmethod
     def user_disconnection_internal_handling(cls, user_name):
-        # TO DO
-        pass
+        # Stopping and removing instance following user disconnection
+        if user_name in cls.users_conversations.keys():
+            related_bot_instance = cls.users_conversations[user_name]
+            del related_bot_instance
+            del cls.users_conversations[user_name]
+
+            return {"result": f"Handled user disconnection {user_name}"}
+
+        else:
+            return {"result": f"Unknown user {user_name}. No instances were stopped."}
+
 
 
 # if __name__ == "__main__":

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ version: '3'
 
 services:
 
-  leonid_the_chatbot:
-      image: leonid_the_chatbot:latest
+  leonid_the_chat_bot:
+      image: leonid_the_chat_bot:latest
       build: ./Leonid
       ports:
         - 5001:5001


### PR DESCRIPTION
Handling 2 important issues:

1.  When a user that has a conversation with the chat bot terminates the connection
      the chatbot should be notified via the newly added  API method in Gateway. After the user name and token are
      validated user's name is passed to the MiddleLayer, and the bot instance that had a conversation
      with that given user is stopped and removed.

2. If a new prompt is sent to the Vicuna model before the previous prompt was processed the application crashes. 
    Added a flag to handle this issue. 